### PR TITLE
Adds support for IPv4 Fragmentation in PacketInterpreter

### DIFF
--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/PacketLayer.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/PacketLayer.java
@@ -17,13 +17,13 @@
  */
 package org.openlvc.sombrero.interpreter;
 
-import java.net.DatagramPacket;
-import java.net.InetAddress;
+import org.openlvc.sombrero.block.EnhancedPacketBlock;
 
 /**
- * Represents User Datagram Protocol information defined within a network packet
+ * A psuedo {@link ProtocolLayer} that is used as the root node of a layer stack, indicating
+ * the {@link EnhancedPacketBlock} that the stack was built from. 
  */
-public class UdpLayer extends ProtocolLayer
+public class PacketLayer extends ProtocolLayer
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -32,32 +32,15 @@ public class UdpLayer extends ProtocolLayer
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
-	private int sourcePort;
-	private int destPort;
-	private int checksum;
+	private EnhancedPacketBlock packet;
 	
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	/**
-	 * Constructor for UdpLayer with specified values
-	 * 
-	 * @param parent the parent layer in the protocol stack (usually IPv4 or IPv6)
-	 * @param sourcePort the sender's port number
-	 * @param destPort the receiver's port number
-	 * @param checksum the packet's checksum
-	 * @param data the packet's data payload
-	 */
-	public UdpLayer( ProtocolLayer parent, 
-	                 int sourcePort, 
-	                 int destPort, 
-	                 int checksum, 
-	                 byte[] data )
+	public PacketLayer( EnhancedPacketBlock packet )
 	{
-		super( parent, data );
-		this.sourcePort = sourcePort;
-		this.destPort = destPort;
-		this.checksum = checksum;
+		super( null, packet.getPacketData() );
+		this.packet = packet;
 	}
 
 	//----------------------------------------------------------
@@ -67,45 +50,10 @@ public class UdpLayer extends ProtocolLayer
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the sender's port number
-	 */
-	public int getSourcePort()
+	@Override
+	public EnhancedPacketBlock getContext()
 	{
-		return this.sourcePort;
-	}
-	
-	/**
-	 * @return the receiver's port number
-	 */
-	public int getDestPort()
-	{
-		return this.destPort;
-	}
-	
-	/**
-	 * @return the packet's checksum
-	 */
-	public int getChecksum()
-	{
-		return this.checksum;
-	}
-	
-	/**
-	 * @return a {@link DatagramPacket} representation of this UDP packet
-	 */
-	public DatagramPacket getDatagram()
-	{
-		// If IPv6 support is added, then we should also add a lookup for the Ip6 parent
-		Ip4Layer ip4Layer = this.findParent( Ip4Layer.class );
-		InetAddress destAddr = null;
-		if( ip4Layer != null )
-			destAddr = ip4Layer.getDestAddress();
-		
-		return new DatagramPacket( getData(), 
-		                           getData().length, 
-		                           destAddr, 
-		                           this.destPort );
+		return this.packet;
 	}
 	
 	//----------------------------------------------------------

--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ProtocolLayer.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ProtocolLayer.java
@@ -17,6 +17,8 @@
  */
 package org.openlvc.sombrero.interpreter;
 
+import org.openlvc.sombrero.block.EnhancedPacketBlock;
+
 /**
  * Abstract data type for conveying a layer within a network protocol stack.
  * <p/>
@@ -43,7 +45,7 @@ public abstract class ProtocolLayer
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
 	/**
-	 * ProtocolLayer constructor for child layers.
+	 * ProtocolLayer constructor
 	 * 
 	 * @param parent the parent layer in the stack
 	 * @param data the layer's data payload
@@ -52,16 +54,6 @@ public abstract class ProtocolLayer
 	{
 		this.parent = parent;
 		this.data = data;
-	}
-	
-	/**
-	 * ProtocolLayer constructor for top-level layers (e.g. Ethernet)
-	 * 
-	 * @param data the layer's data payload
-	 */
-	protected ProtocolLayer( byte[] data )
-	{
-		this( null, data );
 	}
 
 	//----------------------------------------------------------
@@ -103,6 +95,17 @@ public abstract class ProtocolLayer
 		return this.data;
 	}
 
+	/** 
+	 * @return the {@link EnhancedPacketBlock} that this protocol layer is a part of
+	 */
+	public EnhancedPacketBlock getContext()
+	{
+		if( this.parent == null )
+			throw new IllegalStateException( "no parent" );
+		
+		return this.parent.getContext();
+	}
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/RawLayer.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/RawLayer.java
@@ -37,9 +37,9 @@ public class RawLayer extends ProtocolLayer
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public RawLayer( byte[] data )
+	public RawLayer( ProtocolLayer parent, byte[] data )
 	{
-		super( data );
+		super( parent, data );
 	}
 	
 	//----------------------------------------------------------

--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4FragmentManager.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4FragmentManager.java
@@ -1,0 +1,211 @@
+/*
+ *   Copyright 2024 Calytrix Technologies
+ *
+ *   This file is part of sombrero.
+ *
+ *   NOTICE:  All information contained herein is, and remains
+ *            the property of Calytrix Technologies Pty Ltd.
+ *            The intellectual and technical concepts contained
+ *            herein are proprietary to Calytrix Technologies Pty Ltd.
+ *            Dissemination of this information or reproduction of
+ *            this material is strictly forbidden unless prior written
+ *            permission is obtained from Calytrix Technologies Pty Ltd.
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+package org.openlvc.sombrero.interpreter.ip;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class for managing data fragmentation over multiple IPv4 frames.
+ * <p/>
+ * For each IPv4 frame received, call {@link #processFrame(Ip4Layer)}. A {@link SequenceResult} 
+ * will be returned indicating whether enough data has been received to pass onto the next layer in 
+ * the stack. 
+ * <p/>
+ * If the frame is part of a fragmented sequence that is still incomplete, the manager will hold 
+ * onto the frame to resolve the sequence during a future call of {@link #processFrame(Ip4Layer)}.  
+ * <p/>
+ * In order to prevent sequence data from accumulating over time, a time-to-live value is held for 
+ * each sequence. Call {@link #tickTtl()} to increment the ttl counter and remove any stale records.
+ */
+public class Ip4FragmentManager
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	public static final int DEFAULT_TTL = 255;
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private Map<Integer,SequenceHolder> sequences;
+	private int fragmentSequenceTtl;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public Ip4FragmentManager()
+	{
+		this.sequences = new HashMap<>();
+		this.fragmentSequenceTtl = DEFAULT_TTL;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * Processes a single {@link Ip4Layer} frame, resolving it to an outstanding fragmentation 
+	 * sequence, and returning whether that sequence is now complete.
+	 *  
+	 * @param layer the frame to process
+	 * @return an {@link SequenceResult} indicating whether the fragmentation sequence is now
+	 *         complete, and if so, containing the sequence's fragments and reassembled data 
+	 */
+	public SequenceResult processFrame( Ip4Layer layer )
+	{
+		SequenceResult result = SequenceResult.IncompleteResult;
+		if( layer.isPartOfFragmentSequence() )
+		{
+			// Find the tracker for this sequence, or create a new tracker if
+			// it doesn't already exist
+			int fragmentId = layer.getIdentification();
+			SequenceHolder holder = this.sequences
+			                            .computeIfAbsent( fragmentId, 
+			                                              SequenceHolder::new );
+			holder.sequence.addFragment( layer );
+			if( !layer.isMoreFragments() )
+			{
+				// Remote side has advised us that there are no more fragments in this
+				// sequence, so we can free up the tracker
+				this.sequences.remove( fragmentId );
+				
+				// Check to see if all fragments were received for this sequence. 
+				if( holder.sequence.isComplete() )
+					result = SequenceResult.sequenceResult( holder.sequence );
+			}
+		}
+		else
+		{
+			// Not part of a fragment sequence so we can just pass it through
+			result = SequenceResult.standaloneResult( layer );
+		}
+		
+		return result;
+	}
+	
+	/**
+	 * Decrements the time-to-live counter of all outstanding sequences, and removes those that
+	 * are stale 
+	 */
+	public void tickTtl()
+	{
+		// Note: These two steps could potentially be combined into one call to removeIf(), however
+		// mutating a value in removeIf() doesn't seem quite right... 
+		
+		// Decrement ttl value of all current sequences
+		this.sequences.values().forEach( holder -> --holder.ttl );
+		
+		// Remove any stale sequences
+		this.sequences.values().removeIf( holder -> holder.ttl < 1 );
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public int getFragmentSequenceTtl()
+	{
+		return this.fragmentSequenceTtl;
+	}
+	
+	public void setFragmentSequenceTtl( int ttl )
+	{
+		this.fragmentSequenceTtl = ttl;
+		
+		// Clamp any existing ttl values that are greater than the one just set
+		this.sequences.values().forEach( holder -> holder.ttl = Math.max(holder.ttl, ttl) );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class SequenceHolder
+	{
+		private Ip4FragmentSequence sequence;
+		private int ttl;
+		
+		public SequenceHolder( int identifier )
+		{
+			this.sequence = new Ip4FragmentSequence( identifier );
+			this.ttl = fragmentSequenceTtl;
+		}
+	}
+	
+	/**
+	 * Compound result value for the return value of {@link #processFrame(Ip4Layer)}
+	 * <p/>
+	 * The method {@link #isComplete()} indicates whether all fragments in the sequence have been
+	 * received. If the return value is <code>true</code> then the re-assembled data payload can
+	 * be obtained by calling {@link #getPayload()}.
+	 */
+	public static class SequenceResult
+	{
+		protected static final SequenceResult IncompleteResult 
+			= new SequenceResult( false, Collections.emptyList(), new byte[0] );
+		
+		private boolean complete;
+		private Collection<Ip4Layer> fragments;
+		private byte[] payload;
+		
+		private SequenceResult( boolean complete, Collection<Ip4Layer> fragments, byte[] payload )
+		{
+			this.complete = complete;
+			this.fragments = fragments;
+			this.payload = payload;
+		}
+		
+		/**
+		 * @return <code>true</code> if all frames have been received in the fragmentation sequence
+		 */
+		public boolean isComplete()
+		{
+			return this.complete;
+		}
+		
+		/**
+		 * @return the ordered collection of frames in the fragmentation sequence
+		 */
+		public Collection<Ip4Layer> getFragments()
+		{
+			return new ArrayList<>( this.fragments );
+		}
+		
+		/**
+		 * @return the re-assembled data payload for this sequence
+		 */
+		public byte[] getPayload()
+		{
+			return this.payload;
+		}
+		
+		protected static SequenceResult standaloneResult( Ip4Layer layer )
+		{
+			return new SequenceResult( true, Collections.singleton(layer), layer.getData() );
+		}
+		
+		protected static SequenceResult sequenceResult( Ip4FragmentSequence sequence )
+		{
+			return new SequenceResult( true, sequence.getFragments(), sequence.reassemble() );
+		}
+	}
+}

--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4FragmentSequence.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4FragmentSequence.java
@@ -1,0 +1,187 @@
+/*
+ *   Copyright 2024 Calytrix Technologies
+ *
+ *   This file is part of sombrero.
+ *
+ *   NOTICE:  All information contained herein is, and remains
+ *            the property of Calytrix Technologies Pty Ltd.
+ *            The intellectual and technical concepts contained
+ *            herein are proprietary to Calytrix Technologies Pty Ltd.
+ *            Dissemination of this information or reproduction of
+ *            this material is strictly forbidden unless prior written
+ *            permission is obtained from Calytrix Technologies Pty Ltd.
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+package org.openlvc.sombrero.interpreter.ip;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Utility class for reassembling a data payload that is split over multiple packets using
+ * IPv4's fragmentation mechanism.
+ * <p/>
+ * A {@link Ip4FragmentSequence} must be constructed with the sequence identifier it will manage.
+ * The sequence identifier can be obtained from the IP layer data by calling 
+ * {@link Ip4Layer#getIdentification()}.
+ * <p/>
+ * As packets are received for the sequence, they should be added by calling 
+ * {@link #addFragment(Ip4Layer)}.
+ * <p/>
+ * Once all packets in the sequence have been added call {@link #reassemble()} to obtain the 
+ * reassembled sequence data payload.  
+ */
+public class Ip4FragmentSequence
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private int identifier;
+	private SortedSet<Ip4Layer> fragments;
+	private boolean complete;
+	private boolean completeDirty;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	/**
+	 * Ip4FragmentSequence constructor with specified sequence identifier
+	 * 
+	 * @param identifier
+	 */
+	public Ip4FragmentSequence( int identifier )
+	{
+		this.identifier = identifier;
+		this.fragments = new TreeSet<>( Ip4FragmentSequence::compareFragments );
+		this.complete = false;
+		this.completeDirty = false;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * Returns the reassembled data payload of this fragment sequence.
+	 * <p/>
+	 * Note: All packets in the sequence must have been added via the {@link #addFragment(Ip4Layer)}
+	 * method before calling this function.
+	 * 
+	 * @return the reassembled data payload of this fragment sequence
+	 * @throw {@link IllegalStateException} if this sequence is missing fragments
+	 * 
+	 * @see #isComplete()
+	 * @see #addFragment(Ip4Layer)
+	 */
+	public byte[] reassemble()
+	{
+		if( !isComplete() )
+			throw new IllegalStateException( "incomplete sequence" );
+		
+		Ip4Layer lastFragment = this.fragments.getLast();
+		
+		int reassembledSize =   lastFragment.getFragmentOffset() * 8 
+		                      + lastFragment.getData().length;
+		byte[] data = new byte[reassembledSize];
+		for( Ip4Layer fragment : this.fragments )
+		{
+			byte[] fragmentData = fragment.getData();
+			System.arraycopy( fragmentData, 
+			                  0, 
+			                  data, 
+			                  fragment.getFragmentOffset() * 8, 
+			                  fragmentData.length );
+		}
+		
+		return data;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Adds data contained in an {@link Ip4Layer} that is marked as a fragment of this sequence
+	 * 
+	 * @param fragment the fragment to add to this sequence
+	 * @throws IllegalArgumentException if the fragment does not belong to this sequence
+	 */
+	public void addFragment( Ip4Layer fragment )
+	{
+		if( fragment.getIdentification() != this.identifier )
+			throw new IllegalArgumentException( "fragment does not belong to this sequence" );
+		
+		this.fragments.add( fragment );
+		this.completeDirty = true;
+	}
+	
+	/**
+	 * @return the collection of fragments that have been collected for this sequence so far
+	 */
+	public Collection<Ip4Layer> getFragments()
+	{
+		return new ArrayList<>( this.fragments );
+	}
+	
+	/**
+	 * @return <code>true</code> if all fragments have been collected for this sequence, otherwise
+	 *         <code>false</code> if the sequence is still missing fragments
+	 */
+	public boolean isComplete()
+	{
+		if( this.completeDirty )
+		{
+			int expectedOffset = 0;
+			int fragmentCount = this.fragments.size();
+			boolean fragmentsValid = true;
+			int index = 0;
+			for( Ip4Layer fragment : this.fragments )
+			{
+				// Ensure this fragment's offset matches what we expect it to be. If not, we are
+				// missing a fragment in the sequence
+				if( fragment.getFragmentOffset() != expectedOffset )
+					fragmentsValid = false;
+				
+				// If this is the last fragment we have on record, then ensure that the More 
+				// Fragments flag is not set
+				if( index == fragmentCount - 1 && fragment.isMoreFragments() )
+					fragmentsValid = false;
+
+				// Calculate the next fragment's expected offset based on the current fragment's 
+				// data size 
+				if( fragmentsValid )
+					expectedOffset += fragment.getData().length / 8;
+				else
+					break;
+				
+				++index;
+			}
+			
+			this.complete = fragmentsValid;
+			this.completeDirty = false;
+		}
+		
+		return this.complete;
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/*
+	 * Private comparator function to order based on fragment offset
+	 */
+	private static int compareFragments( Ip4Layer a, Ip4Layer b )
+	{
+		return a.getFragmentOffset() - b.getFragmentOffset();
+	}
+}

--- a/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4Layer.java
+++ b/codebase/src/java/sombrero/org/openlvc/sombrero/interpreter/ip/Ip4Layer.java
@@ -15,9 +15,11 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package org.openlvc.sombrero.interpreter;
+package org.openlvc.sombrero.interpreter.ip;
 
 import java.net.InetAddress;
+
+import org.openlvc.sombrero.interpreter.ProtocolLayer;
 
 /**
  * Represents Internet Protocol v4 information defined within a network packet
@@ -115,6 +117,23 @@ public class Ip4Layer extends ProtocolLayer
 	public int getFlags()
 	{
 		return this.flags;
+	}
+	
+	/**
+	 * @return the value of this IP Packet's More Fragments flag
+	 */
+	public boolean isMoreFragments()
+	{
+		return (this.flags & 0x1) != 0;
+	}
+	
+	/**
+	 * @return <code>true</code> if this packet is part of a fragment sequence, or 
+	 *         <code>false</code> if it is self-contained
+	 */
+	public boolean isPartOfFragmentSequence()
+	{
+		return isMoreFragments() || getFragmentOffset() > 0;
 	}
 	
 	/**


### PR DESCRIPTION
This PR is an implementation of the feature requested in https://github.com/michaelrfraser/sombrero/issues/1

- `PacketInterpreter`'s IPv4 handler now checks for fragmentation sequences and does not call child handlers until all frames in a sequence have been accumulated
- Supporting classes for IP packet family interpretation have been moved into their own child package to keep things tidy
- All `ProtocolLayer` chains now have a `PacketLayer` at their root which contains a reference to the `EnhancedPacketBlock` that the chain has been built from.